### PR TITLE
Dataloader optimisation

### DIFF
--- a/lfp/data.py
+++ b/lfp/data.py
@@ -169,8 +169,8 @@ class PlayDataloader():
         if from_tfrecords:
             record_paths = []
             for p in paths:
-                record_paths = tf.io.gfile.glob(str(p/'tf_records/*.tfrecords'))
-            dataset = extract_tfrecords(record_paths, self.include_imgs, ordered=True, num_workers=1)
+                record_paths += tf.io.gfile.glob(str(p/'tf_records/*.tfrecords'))
+            dataset = extract_tfrecords(record_paths, self.include_imgs, ordered=True, num_workers=self.num_workers)
         else:
             dataset = extract_npz(paths)
         # self.print_minutes(dataset)


### PR DESCRIPTION
- mapping transform BEFORE windowing
- var seq lens and goal tiling are computationally expensive (we ought to do on device) so I've removed from dataloader
- multi-threaded tfrecords mapper (NOT the IO, this has to be single threaded)
- action validation also taxing, it could be risky removing but it's also too slow. We should validate our data once off beforehand